### PR TITLE
Support for Vite 7, Node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ PM2 shows the most recent error logs when you fire it up. This can sometimes be 
 ## Changelog
 
 - 0.3.0 (2025-01-28) - Switched to Tailwind version 4, using their first-party Vite plugin - ref: https://tailwindcss.com/blog/tailwindcss-v4#first-party-vite-plugin
+- 0.4.0 (2026-01-14) - Support for Vite 7, Node 20. Amended vite command to explicitly answer Yes to all questions.
 
 ## Feature gaps / known issues
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typespark",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typespark",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "bin": {
         "typespark": "index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typespark",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typespark",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "MIT",
       "bin": {
         "typespark": "index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typespark",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Boilerplate scripts for bringing new full-stack TypeScript projects to life.",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typespark",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Boilerplate scripts for bringing new full-stack TypeScript projects to life.",
   "main": "index.js",
   "bin": {

--- a/typespark
+++ b/typespark
@@ -74,7 +74,8 @@ fi
 ADD_VITEST=false
 
 # Define the path to the boilerplate files
-BOILERPLATE_PATH="$(dirname "$0")/boilerplates"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOILERPLATE_PATH="$SCRIPT_DIR/boilerplates"
 
 echo "Building app with:
 ADD_TAILWIND = $ADD_TAILWIND
@@ -108,8 +109,7 @@ fi
 
 cd $FRONTEND_FOLDER
 
-npm create vite@latest . -- --template react-swc-ts --yes
-# --yes is a shortcut to answer all questions with yes
+npm create vite@latest . -- --template react-swc-ts --no-interactive
 echo "Vite creation completed in $FRONTEND_FOLDER. Proceeding to next stage..."
 
 npm install
@@ -161,6 +161,8 @@ if $ADD_EXPRESS; then
 
   cd ..
   cp $BOILERPLATE_PATH/boilerplate.App.tsx frontend/src/App.tsx
+  echo "Boilerplate_PATH = $BOILERPLATE_PATH"
+  ls -l "$BOILERPLATE_PATH"
   echo "Boilerplate client file updated with server routes in '$APP_NAME/frontend/src/App.tsx'."
 else
   echo "Express server setup skipped."

--- a/typespark
+++ b/typespark
@@ -108,7 +108,8 @@ fi
 
 cd $FRONTEND_FOLDER
 
-npm create vite@latest . -- --template react-swc-ts
+npm create vite@latest . -- --template react-swc-ts --yes
+# --yes is a shortcut to answer all questions with yes
 echo "Vite creation completed in $FRONTEND_FOLDER. Proceeding to next stage..."
 
 npm install


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `typespark` script for Vite 7 and Node 20 support, with non-interactive Vite command.
> 
>   - **Behavior**:
>     - Updated `typespark` script to support Vite 7 and Node 20.
>     - Modified Vite command in `typespark` to use `--no-interactive` flag.
>   - **Versioning**:
>     - Updated version in `package.json` from `0.3.2` to `0.4.0`.
>   - **Documentation**:
>     - Added changelog entry in `README.md` for version 0.4.0.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=yablochko8%2Ftypespark&utm_source=github&utm_medium=referral)<sup> for bc6cd97152e306a6941cccc601a4681fefb1eef7. You can [customize](https://app.ellipsis.dev/yablochko8/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->